### PR TITLE
Nix flake to manage development environment 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake . --impure

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ Thumbs.db
 # Environment variables
 .env
 .env.local
+.direnv
 
 # Test artifacts
 /coverage/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wazuh-client"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["Gianluca Brigandi <gbrigand@gmail.com>"]
 description = "A Rust client library for interacting with Wazuh API and Indexer"

--- a/README.md
+++ b/README.md
@@ -33,46 +33,46 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-wazuh-client = "0.1.0"
+wazuh-client = "0.1.7"
 tokio = { version = "1.0", features = ["full"] }
 ```
 
 ### Basic Usage
 
 ```rust
-use wazuh_client_rs::{WazuhClientFactory, WazuhClients}; // Updated imports
-use std::env; // For environment variables if you choose to load them
+use wazuh_client_rs::{WazuhClientFactory, WazuhClients};
+use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Setup the factory with your Wazuh API and Indexer credentials/details
-    // For a real application, load these from config files or environment variables
-    let factory = WazuhClientFactory::new(
-        env::var("WAZUH_API_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        env::var("WAZUH_API_PORT").unwrap_or_else(|_| "55000".to_string()).parse().unwrap_or(55000),
-        env::var("WAZUH_API_USERNAME").unwrap_or_else(|_| "wazuh".to_string()),
-        env::var("WAZUH_API_PASSWORD").unwrap_or_else(|_| "wazuh".to_string()),
-        env::var("WAZUH_INDEXER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        env::var("WAZUH_INDEXER_PORT").unwrap_or_else(|_| "9200".to_string()).parse().unwrap_or(9200),
-        env::var("WAZUH_INDEXER_USERNAME").unwrap_or_else(|_| "admin".to_string()),
-        env::var("WAZUH_INDEXER_PASSWORD").unwrap_or_else(|_| "admin".to_string()),
-        env::var("WAZUH_VERIFY_SSL").unwrap_or_else(|_| "false".to_string()).parse().unwrap_or(false),
-        Some("https".to_string()) // Or "http" if not using SSL
-    );
+    // Setup the factory with your Wazuh API and Indexer credentials
+    let factory = WazuhClientFactory::builder()
+        .api_host(env::var("WAZUH_API_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()))
+        .api_port(env::var("WAZUH_API_PORT").unwrap_or_else(|_| "55000".to_string()).parse().unwrap_or(55000))
+        .api_credentials(
+            env::var("WAZUH_API_USERNAME").unwrap_or_else(|_| "wazuh".to_string()),
+            env::var("WAZUH_API_PASSWORD").unwrap_or_else(|_| "wazuh".to_string()),
+        )
+        .indexer_host(env::var("WAZUH_INDEXER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()))
+        .indexer_port(env::var("WAZUH_INDEXER_PORT").unwrap_or_else(|_| "9200".to_string()).parse().unwrap_or(9200))
+        .indexer_credentials(
+            env::var("WAZUH_INDEXER_USERNAME").unwrap_or_else(|_| "admin".to_string()),
+            env::var("WAZUH_INDEXER_PASSWORD").unwrap_or_else(|_| "admin".to_string()),
+        )
+        .verify_ssl(env::var("WAZUH_VERIFY_SSL").unwrap_or_else(|_| "false".to_string()).parse().unwrap_or(false))
+        .protocol("https") // Or "http" if not using SSL
+        .build();
 
     // Create a collection of clients
-    // Note: create_all_clients() itself is not async. Methods on the individual clients are.
     let mut clients: WazuhClients = factory.create_all_clients();
 
-    // Get agent summary using the agents client
+    // Get agent summary
     let summary = clients.agents.get_agents_summary().await?;
     println!("Total agents: {}", summary.connection.total);
-    println!("Active agents: {}", summary.connection.active);
 
     // Get a few rules
-    // The get_rules method takes: limit, offset, level, group, filename
     let rules = clients.rules.get_rules(Some(5), None, None, None, None).await?;
-    println!("Fetched {} rules. First rule ID (if any): {:?}", rules.len(), rules.first().map(|r| r.id));
+    println!("Fetched {} rules.", rules.len());
 
     Ok(())
 }
@@ -87,41 +87,18 @@ use std::env;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Assume `factory` is initialized as shown in the Basic Usage example
-    let factory = WazuhClientFactory::new(
-        env::var("WAZUH_API_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        env::var("WAZUH_API_PORT").unwrap_or_else(|_| "55000".to_string()).parse().unwrap_or(55000),
-        env::var("WAZUH_API_USERNAME").unwrap_or_else(|_| "wazuh".to_string()),
-        env::var("WAZUH_API_PASSWORD").unwrap_or_else(|_| "wazuh".to_string()),
-        env::var("WAZUH_INDEXER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        env::var("WAZUH_INDEXER_PORT").unwrap_or_else(|_| "9200".to_string()).parse().unwrap_or(9200),
-        env::var("WAZUH_INDEXER_USERNAME").unwrap_or_else(|_| "admin".to_string()),
-        env::var("WAZUH_INDEXER_PASSWORD").unwrap_or_else(|_| "admin".to_string()),
-        env::var("WAZUH_VERIFY_SSL").unwrap_or_else(|_| "false".to_string()).parse().unwrap_or(false),
-        Some("https".to_string())
-    );
+    let factory = WazuhClientFactory::builder()
+        .api_host("127.0.0.1")
+        .api_credentials("wazuh", "wazuh")
+        .build();
     let mut clients: WazuhClients = factory.create_all_clients();
 
-    // Get agent details (ensure agent "001" exists or use a dynamic ID)
+    // Get agent details
     match clients.agents.get_agent("001").await {
-        Ok(agent) => {
-            println!("Agent 001 Status: {}", agent.status);
-            println!("Agent 001 Name: {}", agent.name);
-        }
-        Err(e) => {
-            eprintln!("Error getting agent 001: {}", e);
-        }
+        Ok(agent) => println!("Agent 001 Status: {}", agent.status),
+        Err(e) => eprintln!("Error getting agent 001: {}", e),
     }
     
-    // Example: Add a new agent (use with caution in production examples)
-    // let new_agent_body = AgentAddBody {
-    //     name: "my-new-agent".to_string(),
-    //     ip: Some("any".to_string()), // "any" or a specific IP
-    // };
-    // match clients.agents.add_agent(new_agent_body).await {
-    //    Ok(added_agent_key) => println!("Added agent. ID: {}, Key: {}", added_agent_key.id, added_agent_key.key),
-    //    Err(e) => eprintln!("Error adding agent: {}", e),
-    // }
-
     Ok(())
 }
 ```
@@ -135,40 +112,19 @@ use std::env;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Assume `factory` is initialized as shown in the Basic Usage example
-    let factory = WazuhClientFactory::new(
-        env::var("WAZUH_API_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        env::var("WAZUH_API_PORT").unwrap_or_else(|_| "55000".to_string()).parse().unwrap_or(55000),
-        env::var("WAZUH_API_USERNAME").unwrap_or_else(|_| "wazuh".to_string()),
-        env::var("WAZUH_API_PASSWORD").unwrap_or_else(|_| "wazuh".to_string()),
-        env::var("WAZUH_INDEXER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        env::var("WAZUH_INDEXER_PORT").unwrap_or_else(|_| "9200".to_string()).parse().unwrap_or(9200),
-        env::var("WAZUH_INDEXER_USERNAME").unwrap_or_else(|_| "admin".to_string()),
-        env::var("WAZUH_INDEXER_PASSWORD").unwrap_or_else(|_| "admin".to_string()),
-        env::var("WAZUH_VERIFY_SSL").unwrap_or_else(|_| "false".to_string()).parse().unwrap_or(false),
-        Some("https".to_string())
-    );
+    let factory = WazuhClientFactory::builder()
+        .api_host("127.0.0.1")
+        .api_credentials("wazuh", "wazuh")
+        .build();
     let mut clients: WazuhClients = factory.create_all_clients();
 
-    // Get a few rules (limit, offset, level, group, filename)
+    // Get a few rules
     let rules = clients.rules.get_rules(Some(5), None, None, None, None).await?;
     println!("Fetched {} rules.", rules.len());
 
-    if let Some(rule) = rules.first() {
-        println!("Example Rule ID: {}, Description: {}", rule.id, rule.description);
-    }
-
-    // Search for rules containing "ssh" in their description (or other indexed fields)
-    // Note: The `search` parameter for `get_rules` is not directly in its signature.
-    // The general `search` parameter is usually part of a more generic query structure if supported.
-    // The `src/rules.rs` `get_rules` method does not have a `search` parameter.
-    // To search, you might need to iterate or use a different endpoint if available.
-    // For simplicity, this example will fetch rules by group.
+    // Get rules by group
     let ssh_rules = clients.rules.get_rules_by_group("ssh").await?;
     println!("Found {} rules in the 'ssh' group.", ssh_rules.len());
-    if let Some(rule) = ssh_rules.first() {
-        println!("Example SSH Rule ID: {}, Description: {}", rule.id, rule.description);
-    }
-
 
     Ok(())
 }
@@ -183,47 +139,22 @@ use std::env;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Assume `factory` is initialized as shown in the Basic Usage example
-    let factory = WazuhClientFactory::new(
-        env::var("WAZUH_API_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        env::var("WAZUH_API_PORT").unwrap_or_else(|_| "55000".to_string()).parse().unwrap_or(55000),
-        env::var("WAZUH_API_USERNAME").unwrap_or_else(|_| "wazuh".to_string()),
-        env::var("WAZUH_API_PASSWORD").unwrap_or_else(|_| "wazuh".to_string()),
-        env::var("WAZUH_INDEXER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        env::var("WAZUH_INDEXER_PORT").unwrap_or_else(|_| "9200".to_string()).parse().unwrap_or(9200),
-        env::var("WAZUH_INDEXER_USERNAME").unwrap_or_else(|_| "admin".to_string()),
-        env::var("WAZUH_INDEXER_PASSWORD").unwrap_or_else(|_| "admin".to_string()),
-        env::var("WAZUH_VERIFY_SSL").unwrap_or_else(|_| "false".to_string()).parse().unwrap_or(false),
-        Some("https".to_string())
-    );
+    let factory = WazuhClientFactory::builder()
+        .api_host("127.0.0.1")
+        .api_credentials("wazuh", "wazuh")
+        .build();
     let mut clients: WazuhClients = factory.create_all_clients();
 
     // Get cluster status
     match clients.cluster.get_cluster_status().await {
-        Ok(status) => {
-            println!("Cluster enabled: {}", status.enabled);
-            println!("Cluster running: {}", status.running);
-        }
-        Err(e) => {
-            eprintln!("Error getting cluster status (this is expected in non-clustered environments): {}", e);
-        }
+        Ok(status) => println!("Cluster enabled: {}", status.enabled),
+        Err(e) => eprintln!("Error getting cluster status: {}", e),
     }
 
-    // Get cluster nodes (limit, offset, node_type)
-    // This will likely error in a single-node setup.
+    // Get cluster nodes
     match clients.cluster.get_cluster_nodes(None, None, None).await {
-        Ok(nodes) => {
-            if nodes.is_empty() {
-                println!("No cluster nodes found (or single node deployment).");
-            } else {
-                println!("Cluster Nodes:");
-                for node in nodes {
-                    println!("  Node: {}, Type: {}, Status: {}", node.name, node.node_type, node.status);
-                }
-            }
-        }
-        Err(e) => {
-             eprintln!("Error getting cluster nodes (this is expected in non-clustered environments): {}", e);
-        }
+        Ok(nodes) => println!("Found {} cluster nodes.", nodes.len()),
+        Err(e) => eprintln!("Error getting cluster nodes: {}", e),
     }
 
     Ok(())
@@ -233,39 +164,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Log Analysis with Indexer
 
 ```rust
-use wazuh_client_rs::{WazuhClientFactory, WazuhClients}; // WazuhIndexerClient is part of WazuhClients
+use wazuh_client_rs::{WazuhClientFactory, WazuhClients};
 use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Assume `factory` is initialized as shown in the Basic Usage example
-    // Ensure indexer details are correctly set in the factory
-    let factory = WazuhClientFactory::new(
-        env::var("WAZUH_API_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        env::var("WAZUH_API_PORT").unwrap_or_else(|_| "55000".to_string()).parse().unwrap_or(55000),
-        env::var("WAZUH_API_USERNAME").unwrap_or_else(|_| "wazuh".to_string()),
-        env::var("WAZUH_API_PASSWORD").unwrap_or_else(|_| "wazuh".to_string()),
-        env::var("WAZUH_INDEXER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        env::var("WAZUH_INDEXER_PORT").unwrap_or_else(|_| "9200".to_string()).parse().unwrap_or(9200),
-        env::var("WAZUH_INDEXER_USERNAME").unwrap_or_else(|_| "admin".to_string()),
-        env::var("WAZUH_INDEXER_PASSWORD").unwrap_or_else(|_| "admin".to_string()),
-        env::var("WAZUH_VERIFY_SSL").unwrap_or_else(|_| "false".to_string()).parse().unwrap_or(false),
-        Some("https".to_string())
-    );
-    let clients: WazuhClients = factory.create_all_clients(); // Indexer client is part of WazuhClients
+    // Ensure indexer details are correctly set
+    let factory = WazuhClientFactory::builder()
+        .indexer_host("127.0.0.1")
+        .indexer_credentials("admin", "admin")
+        .build();
+    let clients: WazuhClients = factory.create_all_clients();
 
-    // Get recent alerts using the indexer client from WazuhClients
-    match clients.indexer.get_alerts().await {
-        Ok(alerts) => {
-            println!("Retrieved {} alerts from the indexer.", alerts.len());
-            if let Some(alert) = alerts.first() {
-                // Alerts are serde_json::Value, you can explore them
-                println!("Example alert (first 50 chars): {:.50}", serde_json::to_string(alert)?);
-            }
-        }
-        Err(e) => {
-            eprintln!("Error getting alerts from indexer: {}", e);
-        }
+    // Get recent alerts
+    match clients.indexer.get_alerts(Some(10)).await {
+        Ok(alerts) => println!("Retrieved {} alerts.", alerts.len()),
+        Err(e) => eprintln!("Error getting alerts: {}", e),
     }
 
     Ok(())
@@ -279,10 +193,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 You can configure the client using environment variables:
 
 ```bash
-export WAZUH_HOST="https://your-wazuh-manager.com"
-export WAZUH_PORT="55000"
-export WAZUH_USERNAME="wazuh"
-export WAZUH_PASSWORD="your-password"
+export WAZUH_API_HOST="https://your-wazuh-manager.com"
+export WAZUH_API_PORT="55000"
+export WAZUH_API_USERNAME="wazuh"
+export WAZUH_API_PASSWORD="your-password"
 export WAZUH_VERIFY_SSL="true"
 
 export WAZUH_INDEXER_HOST="your-wazuh-indexer.com"
@@ -293,33 +207,33 @@ export WAZUH_INDEXER_PASSWORD="admin"
 
 ### Client Factory Initialization
 
-The `WazuhClientFactory` is used to configure and create clients.
+The `WazuhClientFactory` is used to configure and create clients using a builder pattern.
 
 ```rust
 use wazuh_client_rs::WazuhClientFactory;
 use std::env;
 
-// Example of initializing the factory
-// In a real application, load these from a configuration file or environment variables.
-let factory = WazuhClientFactory::new(
-    env::var("WAZUH_API_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-    env::var("WAZUH_API_PORT").unwrap_or_else(|_| "55000".to_string()).parse().unwrap_or(55000),
-    env::var("WAZUH_API_USERNAME").unwrap_or_else(|_| "wazuh".to_string()),
-    env::var("WAZUH_API_PASSWORD").unwrap_or_else(|_| "wazuh".to_string()),
-    env::var("WAZUH_INDEXER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-    env::var("WAZUH_INDEXER_PORT").unwrap_or_else(|_| "9200".to_string()).parse().unwrap_or(9200),
-    env::var("WAZUH_INDEXER_USERNAME").unwrap_or_else(|_| "admin".to_string()),
-    env::var("WAZUH_INDEXER_PASSWORD").unwrap_or_else(|_| "admin".to_string()),
-    env::var("WAZUH_VERIFY_SSL").unwrap_or_else(|_| "false".to_string()).parse().unwrap_or(false), // Set to true in production with valid certs
-    Some("https".to_string()) // Protocol: "http" or "https"
-);
+// Example of initializing the factory using the builder
+let factory = WazuhClientFactory::builder()
+    .api_host(env::var("WAZUH_API_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()))
+    .api_port(env::var("WAZUH_API_PORT").unwrap_or_else(|_| "55000".to_string()).parse().unwrap_or(55000))
+    .api_credentials(
+        env::var("WAZUH_API_USERNAME").unwrap_or_else(|_| "wazuh".to_string()),
+        env::var("WAZUH_API_PASSWORD").unwrap_or_else(|_| "wazuh".to_string()),
+    )
+    .indexer_host(env::var("WAZUH_INDEXER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()))
+    .indexer_port(env::var("WAZUH_INDEXER_PORT").unwrap_or_else(|_| "9200".to_string()).parse().unwrap_or(9200))
+    .indexer_credentials(
+        env::var("WAZUH_INDEXER_USERNAME").unwrap_or_else(|_| "admin".to_string()),
+        env::var("WAZUH_INDEXER_PASSWORD").unwrap_or_else(|_| "admin".to_string()),
+    )
+    .verify_ssl(env::var("WAZUH_VERIFY_SSL").unwrap_or_else(|_| "false".to_string()).parse().unwrap_or(false))
+    .protocol("https")
+    .build();
 
 // Then, create specific clients or all clients:
 // let mut agents_client = factory.create_agents_client();
-// let mut rules_client = factory.create_rules_client();
-// OR
 // let mut all_clients = factory.create_all_clients();
-// let agent_summary = all_clients.agents.get_agents_summary().await?;
 ```
 
 ## Error Handling
@@ -332,47 +246,15 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Assume `factory` is initialized as shown in the Basic Usage example
-    let factory = WazuhClientFactory::new(
-        env::var("WAZUH_API_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        env::var("WAZUH_API_PORT").unwrap_or_else(|_| "55000".to_string()).parse().unwrap_or(55000),
-        env::var("WAZUH_API_USERNAME").unwrap_or_else(|_| "wazuh".to_string()),
-        env::var("WAZUH_API_PASSWORD").unwrap_or_else(|_| "wazuh".to_string()),
-        env::var("WAZUH_INDEXER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        env::var("WAZUH_INDEXER_PORT").unwrap_or_else(|_| "9200".to_string()).parse().unwrap_or(9200),
-        env::var("WAZUH_INDEXER_USERNAME").unwrap_or_else(|_| "admin".to_string()),
-        env::var("WAZUH_INDEXER_PASSWORD").unwrap_or_else(|_| "admin".to_string()),
-        env::var("WAZUH_VERIFY_SSL").unwrap_or_else(|_| "false".to_string()).parse().unwrap_or(false),
-        Some("https".to_string())
-    );
+    // Assume `factory` is initialized
+    let factory = WazuhClientFactory::builder().build();
     let mut clients: WazuhClients = factory.create_all_clients();
 
     match clients.agents.get_agent("invalid-id-123").await {
         Ok(agent) => println!("Agent: {:?}", agent.name),
         Err(WazuhApiError::HttpError { status, message, .. }) => {
-            // Specific HTTP errors, e.g. 404 Not Found, 401 Unauthorized
             eprintln!("HTTP Error {}: {}", status, message);
-            if status == reqwest::StatusCode::NOT_FOUND {
-                eprintln!("The agent 'invalid-id-123' was not found.");
-            } else if status == reqwest::StatusCode::UNAUTHORIZED {
-                eprintln!("Authentication failed. Check your API credentials.");
-            }
         }
-        Err(WazuhApiError::AuthenticationError(msg)) => {
-            eprintln!("Wazuh API Authentication Error: {}", msg);
-        }
-        Err(WazuhApiError::ApiError(msg)) => {
-            // General API errors reported by Wazuh
-            eprintln!("Wazuh API Error: {}", msg);
-        }
-        Err(WazuhApiError::RequestError(reqwest_err)) => {
-            // Errors from the underlying reqwest client (network issues, timeouts)
-            eprintln!("Network or Request Error: {}", reqwest_err);
-        }
-        Err(WazuhApiError::JsonError(json_err)) => {
-            eprintln!("JSON Parsing Error: {}", json_err);
-        }
-        // Handle other variants as needed
         Err(e) => eprintln!("An unexpected error occurred: {}", e),
     }
     Ok(())

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751211869,
+        "narHash": "sha256-1Cu92i1KSPbhPCKxoiVG5qnoRiKTgR5CcGSRyLpOd7Y=",
+        "rev": "b43c397f6c213918d6cfe6e3550abfe79b5d1c51",
+        "revCount": 805252,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.805252%2Brev-b43c397f6c213918d6cfe6e3550abfe79b5d1c51/0197c007-f18c-7f97-aeb6-aed117320dd2/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/%2A.tar.gz"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1751510438,
+        "narHash": "sha256-m8PjOoyyCR4nhqtHEBP1tB/jF+gJYYguSZmUmVTEAQE=",
+        "rev": "7f415261f298656f8164bd636c0dc05af4e95b6b",
+        "revCount": 1836,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/oxalica/rust-overlay/0.1.1836%2Brev-7f415261f298656f8164bd636c0dc05af4e95b6b/0197ce2a-511d-765d-8116-8bb7d753ca22/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/oxalica/rust-overlay/%2A.tar.gz"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  inputs = {
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/*.tar.gz";
+    rust-overlay.url = "https://flakehub.com/f/oxalica/rust-overlay/*.tar.gz";
+  };
+
+  outputs = {
+    nixpkgs,
+    rust-overlay,
+    ...
+  }: let
+    rustVersion = "1.86.0";
+
+    allSystems = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+
+    forEachSystem = f:
+      nixpkgs.lib.genAttrs allSystems (system:
+        f {
+          inherit system;
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              rust-overlay.overlays.default
+            ];
+          };
+        });
+  in {
+    devShells = forEachSystem ({pkgs, system}: {
+      default = import ./nix/devShell.nix {
+        inherit pkgs rustVersion;
+      };
+    });
+  };
+}

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -1,0 +1,63 @@
+{ pkgs, rustVersion }:
+let
+  rustDevEnv = pkgs.rust-bin.stable."${rustVersion}".default.override {
+    extensions = [ "rust-src" "rust-analyzer" ];
+  };
+in
+pkgs.mkShell {
+  packages = with pkgs; [
+    # Rust toolchain
+    rustDevEnv
+
+    # Build dependencies (required by reqwest and other deps)
+    pkg-config
+    openssl
+
+    # Development tools
+    just
+    cargo-nextest
+    cargo-watch
+    cargo-audit
+
+    # Debugging
+    lldb
+
+    # Git hooks
+    pre-commit
+  ];
+
+  shellHook = ''
+    # Unset rustup environment variables to prevent conflicts with Nix-managed Rust
+    unset RUSTUP_TOOLCHAIN
+    unset RUSTUP_HOME
+    
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Wazuh Client Library - Rust Development Environment"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "  Project          : wazuh-client-rs (library)"
+    echo "  Rust version     : ${rustVersion}"
+    echo "  Toolchain        : ${rustDevEnv}/bin"
+    echo "  Standard Library : ${rustDevEnv}/lib/rustlib/src/rust"
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+
+    export RUST_SRC_PATH="${rustDevEnv}/lib/rustlib/src/rust/library"
+
+    echo "Available commands:"
+    echo "  cargo build              - Build the library"
+    echo "  cargo test               - Run tests"
+    echo "  cargo nextest run        - Run tests with nextest"
+    echo "  cargo doc --open         - Generate and open documentation"
+    echo "  cargo run --example NAME - Run an example"
+    echo ""
+    echo "Examples: basic_usage, agent_management, cluster_monitoring,"
+    echo "          rule_management, log_analysis, vulnerability_detection"
+    echo ""
+  '';
+
+  # Environment variables for SSL/TLS (required by reqwest)
+  SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+}


### PR DESCRIPTION
Use nix flakes to create a reproducible development environment. Rust version can be managed with a flake variable.

Its use is optional, only for those that use nix.